### PR TITLE
fix: `MODULE_NOT_FOUND` error when extending config from @commitlint/config-conventional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ RUN cd /commitlint && npm install .
 
 ENV PATH /commitlint/node_modules/.bin:$PATH
 
+# https://github.com/conventional-changelog/commitlint/issues/613#issuecomment-1302587361
+ENV NODE_PATH /commitlint/node_modules
+
 ENTRYPOINT ["commitlint"]


### PR DESCRIPTION
Set the `NODE_PATH` environment variable to make commitlint discover the package `@commitlint/config-conventional`.